### PR TITLE
Add braintree nonce support spec

### DIFF
--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -53,6 +53,16 @@ class BraintreeBlueTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_transaction_uses_payment_method_nonce_when_option
+    Braintree::TransactionGateway.any_instance.expects(:sale).
+      with(has_entries(:payment_method_nonce => "present")).
+      returns(braintree_result)
+
+    assert response = @gateway.purchase(10, 'present', { payment_method_nonce: true })
+    assert_instance_of Response, response
+    assert_success response
+  end
+
   def test_void_transaction
     Braintree::TransactionGateway.any_instance.expects(:void).
       with('transaction_id').


### PR DESCRIPTION
Added a spec for `payment_method_nonce`. You should also rebase and fix the conflicts due to apple pay support additions.
